### PR TITLE
Implement --modules option

### DIFF
--- a/.changeset/unlucky-keys-whisper.md
+++ b/.changeset/unlucky-keys-whisper.md
@@ -1,0 +1,5 @@
+---
+"0gql": patch
+---
+
+Implement --modules option

--- a/ops/dev.sh
+++ b/ops/dev.sh
@@ -5,5 +5,6 @@ set -eu
 yarn ts-node ./src/bin.ts "src/tests/ts/*.ts"
 yarn ts-node ./src/bin.ts "src/tests/tsx/*.ts*"
 yarn ts-node ./src/bin.ts "src/tests/fragments/*.ts"
+yarn ts-node ./src/bin.ts "src/tests/multiple-gql-tag-modules/*.ts" --modules graphql-tag,@apollo/client
 yarn ts-node ./src/bin.ts "src/tests/graphqls/*.ts" --extension ".graphqls"
 yarn prettier -w src/tests

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -11,6 +11,11 @@ program
     "extension of the generated file/s",
     ".graphql"
   )
+  .option(
+    "-m, --modules <gql tag module/s>",
+    "Module/s where gql tag could be imported from. Comma separated.",
+    "graphql-tag"
+  )
   .argument("<file pattern>")
   .action((filePattern, options) => {
     glob(filePattern, (globErr, files) => {
@@ -23,7 +28,10 @@ program
       files.map((file) => console.log(file));
       console.log("");
 
-      main(files, { targetExtension: options.extension })
+      main(files, {
+        targetExtension: options.extension,
+        gqlTagModules: options.modules.split(","),
+      })
         .then((files) => {
           if (files.length > 0) {
             console.log("Generated files:");

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ interface GeneratedFile {
 
 interface ParsedOptions {
   targetExtension: string;
+  gqlTagModules: string[];
 }
 
 export const main = async (
@@ -61,7 +62,11 @@ export const main = async (
     ts.forEachChild(sourceFile, (node: ts.Node) => {
       // Check imports for gqlTagIdentifiers
       if (ts.isImportDeclaration(node)) {
-        const identifiers = parseGqlTagImportIdentifiers(node, sourceFile);
+        const identifiers = parseGqlTagImportIdentifiers({
+          node,
+          source: sourceFile,
+          gqlTagModules: options.gqlTagModules,
+        });
         Object.entries(identifiers).forEach(([key, moduleMeta]) => {
           if (moduleMeta.isGqlTagModule) {
             indentifiers.gqlTags[key] = moduleMeta;

--- a/src/tests/multiple-gql-tag-modules/test.graphql
+++ b/src/tests/multiple-gql-tag-modules/test.graphql
@@ -1,0 +1,12 @@
+query Test1 {
+  car {
+    id
+    make
+  }
+}
+mutation Test3 {
+  deleteThing(id: "420") {
+    id
+    deletedAt
+  }
+}

--- a/src/tests/multiple-gql-tag-modules/test.ts
+++ b/src/tests/multiple-gql-tag-modules/test.ts
@@ -1,0 +1,30 @@
+import gql from "graphql-tag";
+import { gql as gql2 } from "@not/gql-tag";
+import { gql as gql3 } from "@apollo/client";
+
+export const TEST_1 = gql`
+  query Test1 {
+    car {
+      id
+      make
+    }
+  }
+`;
+
+export const TEST_2 = gql2`
+  query Test2 {
+    car {
+      id
+      make
+    }
+  }
+`;
+
+export const TEST_3 = gql3`
+  mutation Test3 {
+    deleteThing(id: "420") {
+      id
+      deletedAt
+    }
+  }
+`;

--- a/src/utils/parseGqlTagImportIdentifiers.ts
+++ b/src/utils/parseGqlTagImportIdentifiers.ts
@@ -2,18 +2,25 @@ import ts from "typescript";
 import { IdentifierMeta } from "../types";
 import { trimQuotes } from "./trimQuotes";
 
+interface ParseGqlTagImportIdentifiersParams {
+  node: ts.ImportDeclaration;
+  source: ts.SourceFile;
+  gqlTagModules: string[];
+}
+
 /**
  * Function to parse an ImportDeclaration node,
  * returns an array of identifiers that might or might not be used as gql tag
  */
-export const parseGqlTagImportIdentifiers = (
-  node: ts.ImportDeclaration,
-  source: ts.SourceFile
-): Record<string, IdentifierMeta> => {
+export const parseGqlTagImportIdentifiers = ({
+  node,
+  source,
+  gqlTagModules,
+}: ParseGqlTagImportIdentifiersParams): Record<string, IdentifierMeta> => {
   const module = trimQuotes(node.moduleSpecifier.getText(source));
 
   // TODO: there are other modules to check. Maybe let users pass it in?
-  const isGqlTagModule = module === "graphql-tag";
+  const isGqlTagModule = gqlTagModules.includes(module);
 
   const identifiers: Record<string, IdentifierMeta> = {};
 


### PR DESCRIPTION
`gql` tag could be imported from many modules.

This PR adds `--modules` option which allows passing in custom options as comma separated list. 